### PR TITLE
fix `randomMatrix` ambiguous overload with default argument

### DIFF
--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -167,7 +167,7 @@ template makeMatrixIJ*(A: typedesc, M1, N1: int, f: untyped, ord = colMajor): au
         r.data[i * N1 + j] = f
   r
 
-proc randomMatrix*[A: SomeFloat](M, N: int, max: A = 1, order = colMajor): Matrix[A] =
+proc randomMatrix*[A: SomeFloat](M, N: int, max: A, order = colMajor): Matrix[A] =
   result = matrix[A](order, M, N, newSeq[A](M * N))
   for i in 0 ..< (M * N):
     result.data[i] = rand(max)


### PR DESCRIPTION
`randomMatrix` has 2 overloads:

```nim
proc randomMatrix*[A: SomeFloat](M, N: int, max: A = 1, order = colMajor): Matrix[A]
proc randomMatrix*(M, N: int, order = colMajor): Matrix[float64]
```

The second overload is just an alias for `randomMatrix(M, N, 1'f64, order)`, however the first overload already has a default argument `1` for `max`, so this causes an ambiguous overload as detected in https://github.com/nim-lang/Nim/pull/22143.